### PR TITLE
feat: added configurable scheduler

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ env:
   DOCKER_REPOSITORY: ${{ secrets.DOCKER_REPOSITORY }}
   INTERVAL: ${{ secrets.INTERVAL }}
   PERCENTAGE: ${{ secrets.PERCENTAGE }}
+  SCHEDULER_SCHEDULE: ${{ secrets.SCHEDULER_SCHEDULE }}
+  SCHEDULER_TIMEZONE: ${{ secrets.SCHEDULER_TIMEZONE }}
 
 jobs:
   healthcheck:
@@ -84,7 +86,7 @@ jobs:
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          known_hosts: 'just-a-placeholder-so-we-dont-get-errors'
+          known_hosts: "just-a-placeholder-so-we-dont-get-errors"
       - name: Adding Known Hosts
         run: ssh-keyscan -p 2220 -H h2899527.stratoserver.net >> ~/.ssh/known_hosts
       - name: Run Ansible Playbook

--- a/deploy_playbook.yml
+++ b/deploy_playbook.yml
@@ -60,6 +60,8 @@
                 - JWT_SECRET={{ JWT_SECRET }}
                 - INTERVAL={{ INTERVAL }}
                 - PERCENTAGE={{ PERCENTAGE }}
+                - SCHEDULER_SCHEDULE={{ SCHEDULER_SCHEDULE }}
+                - SCHEDULER_TIMEZONE={{ SCHEDULER_TIMEZONE }}
               depends_on:
                 - db
             db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - INIT_HISTORY=false #${INIT_HISTORY}
       - INTERVAL=3 #${INTERVAL}
       - PERCENTAGE=2.1 #${PERCENTAGE}
+      - SCHEDULER_SCHEDULE="0 30 23 * * *"
+      - SCHEDULER_TIMEZONE="EST"
     depends_on:
       - db
   db:

--- a/src/main/java/com/mobsys/easyStocks/service/StockUpdateService.java
+++ b/src/main/java/com/mobsys/easyStocks/service/StockUpdateService.java
@@ -86,7 +86,7 @@ public class StockUpdateService {
         }
     }
 
-    @Scheduled(cron = "0 30 23 * * *", zone = "EST")
+    @Scheduled(cron = "${scheduler.schedule}", zone = "${scheduler.timezone}")
     public final void updateDailyStockData() {
         logger.info("Start getting Daily Stock Data");
         saveDailyStocksData(false);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,5 @@ init_history=${INIT_HISTORY}
 jwt.secret=${JWT_SECRET}
 interval=${INTERVAL}
 percentage=${PERCENTAGE}
+scheduler.schedule=${SCHEDULER_SCHEDULE}
+scheduler.timezone=${SCHEDULER_TIMEZONE}


### PR DESCRIPTION
Würde vorschlagen, 4x pro Tag, alle 3 Stunden auf Notifications zu prüfen. Eventuell niedrige Percentage, z.B. 1% oder 0.5%?
Cron Expr. für 4x tgl. `0 30 6,12,18,23 * * *`, führt aus um: 6:30, 12:30, 18:30, 23:30
Timezone `EST`